### PR TITLE
Fix single file rule argument

### DIFF
--- a/sgrep.py
+++ b/sgrep.py
@@ -273,6 +273,16 @@ def rewrite_message_with_metavars(yaml_rule, sgrep_result):
 def collect_rules(yaml_file_or_dirs: str) -> Tuple[List[Dict[str, Any]], Tuple[int, int]]:
     collected_rules = []
     errors, not_errors = 0, 0
+    if os.path.isfile(yaml_file_or_dirs):
+        file_path = os.path.abspath(yaml_file_or_dirs)
+        rules_in_file = parse_sgrep_yml(file_path)
+        if rules_in_file is None:
+            errors += 1
+        else:
+            not_errors += 1
+        collected_rules.extend(rules_in_file)
+        return collected_rules, (errors, not_errors)
+
     for root, dirs, files in os.walk(yaml_file_or_dirs):
         dirs.sort()
         for filename in sorted(files):


### PR DESCRIPTION
When passing single file, os.walk was skipping over the rules in it.
This fixes that.

To test: run `sgrep-lint` with single rule file and see the rule firing and the error/success counter correctly applied.
```
ulziibayarotgonbaatar@ulziibayars-MacBook-Pro sgrep % sgrep-lint ~/Workspace/sgrep-rules/python/flask/secure-static-file-serve.yaml ~/Workspace/sgrep-rules/tests/python/flask/send_static_file/test_send_file_without_path_sanitization.py| jq
running 1 rules from 1 yaml files (0 yaml files were invalid)
{
  "matches": [
    {
      "check_id": "avoid_send_file_without_path_sanitization",
      "path": "/Users/ulziibayarotgonbaatar/Workspace/sgrep-rules/tests/python/flask/send_static_file/test_send_file_without_path_sanitization.py",
      "start": {
        "line": 8,
        "col": 10,
        "offset": 149
      },
      "end": {
        "line": 8,
        "col": 28,
        "offset": 167
      },
      "extra": {
        "message": "Looks like `filename` could flow to `flask.send_file()` function. Make sure to properly sanitize filename or use `flask.send_from_directory`",
        "metavars": {}
      }
    }
  ]
}
```