### PR TITLE
better handling of invalid keys

### DIFF
--- a/sgrep.py
+++ b/sgrep.py
@@ -149,14 +149,18 @@ def _parse_boolean_expression(rule_patterns, pattern_id=0, prefix=""):
     for pattern in rule_patterns:
         for boolean_operator, pattern_text in pattern.items():
             operator = operator_for_pattern_name(boolean_operator)
-            if isinstance(pattern_text, list):                
-                sub_expression = _parse_boolean_expression(pattern_text, 0, f"{prefix}.{pattern_id}")
+            if isinstance(pattern_text, list):
+                sub_expression = _parse_boolean_expression(
+                    pattern_text, 0, f"{prefix}.{pattern_id}"
+                )
                 yield (operator, NO_BOOLEAN_RULE_ID, list(sub_expression))
             elif isinstance(pattern_text, str):
                 yield (operator, f"{prefix}.{pattern_id}", pattern_text)
                 pattern_id += 1
             else:
-                raise TypeError(f'invalid type for pattern {pattern}: {type(pattern_text)}')
+                raise TypeError(
+                    f"invalid type for pattern {pattern}: {type(pattern_text)}"
+                )
 
 
 def build_boolean_expression(rule):
@@ -174,6 +178,7 @@ def build_boolean_expression(rule):
 
 def operator_for_pattern_name(pattern_name: str) -> str:
     return PATTERN_NAMES_MAP[pattern_name]
+
 
 def pattern_name_for_operator(operator: str) -> str:
     return INVERSE_PATTERN_NAMES_MAP[operator]

--- a/testlint/python/bad.yaml
+++ b/testlint/python/bad.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: eqeq-is-bad
+    patterns:
+      - pattern-inside:
+        - pattern: $X == $X
+        - pattern: $X != $X
+        - patterns:          
+          - pattern-inside: |
+              def __init__(...):
+                  ...
+          - pattern: self.$X == self.$X
+      - pattern-not: 1 == 1
+    message: "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
+    languages: [python]
+    severity: ERROR

--- a/testlint/run-lint-tests.sh
+++ b/testlint/run-lint-tests.sh
@@ -6,9 +6,13 @@ cd "$(dirname "$(realpath "$0")")";
 PYTHONPATH=.. python3 test_lint.py
 
 cd ..
-./sgrep.py --config testlint/python tests/lint | tee tmp.out
+./sgrep.py --strict --config testlint/python/eqeq.yaml tests/lint | tee tmp.out
 diff tmp.out ./testlint/python/eqeq.expected.json
 rm -f tmp.out
+
+# parsing bad.yaml should fail 
+./sgrep.py --strict --config testlint/python/bad.yaml tests/lint && exit 1
+
 
 echo "-----------------------"
 echo "all lint tests complete"


### PR DESCRIPTION
If evaluation of an expression fails, you will now see:

```
AssertionError: only `pattern-either` or `patterns` expressions can have multiple subpatterns
```

Instead of "invalid index [2]..."

Closes https://github.com/returntocorp/sgrep/issues/91