### PR TITLE
This should fix issue #106

### DIFF
--- a/bin/main_sgrep.ml
+++ b/bin/main_sgrep.ml
@@ -330,6 +330,7 @@ let sgrep_with_rules rules_file xs =
     let errs = ref [] in
     let matches = 
       files |> List.map (fun file ->
+         if !verbose then pr2 (spf "Analyzing %s" file);
          try 
            let ast = Parse_generic.parse_with_lang lang file in
            Sgrep_lint_generic.check rules file ast

--- a/lib/match_result.ml
+++ b/lib/match_result.ml
@@ -74,7 +74,7 @@ let match_to_json x =
           "end", endp;
           "abstract_content", J.String (
               any
-              |> Lib_ast.ii_of_any
+              |> Lib_ast.ii_of_any |> List.filter PI.is_origintok
               |> List.sort Parse_info.compare_pos
               |> List.map PI.str_of_info 
               |> Matching_report.join_with_space_if_needed
@@ -98,6 +98,6 @@ let error tok rule =
       E.warning tok (E.SgrepLint (rule.R.id, rule.R.message))
 
 let match_to_error x = 
-  let toks = Lib_ast.ii_of_any x.code in
+  let toks = Lib_ast.ii_of_any x.code |> List.filter PI.is_origintok in
   let tok = List.hd toks in
   error tok x.rule


### PR DESCRIPTION
Test plan:
in bento-core/ repo
git checkout lomalley/sgrep-test
~/sgrep/.../main_sgrep.exe -verbose -rules_file .sgrep.yml bento/

no exn anymore