### PR TITLE
add a flag to skip pattern validation, which takes 0.05 seconds per rule

### DIFF
--- a/sgrep.py
+++ b/sgrep.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-import time
 import base64
 import collections
 import itertools
@@ -11,6 +10,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import time
 import traceback
 from dataclasses import dataclass
 from datetime import datetime

--- a/sgrep.py
+++ b/sgrep.py
@@ -859,7 +859,7 @@ def main(args: argparse.Namespace):
     # actually invoke sgrep
     start = datetime.now()
     output_json = invoke_sgrep(all_patterns, targets, strict)
-    print_error(f"sgrep ran in {datetime.now() - start}")
+    debug_print(f"sgrep ran in {datetime.now() - start}")
     debug_print(str(output_json))
 
     # group output; we want to see all of the same rule ids on the same file path

--- a/sgrep.py
+++ b/sgrep.py
@@ -542,7 +542,8 @@ def resolve_config(config_str: Optional[str]) -> Any:
         config = download_config(config_str)
     else:
         config = load_config(config_str)
-    debug_print(f"loaded {len(config)} configs in {time.time() - start_t}")
+    if config:
+        debug_print(f"loaded {len(config)} configs in {time.time() - start_t}")
     return config
 
 

--- a/sgrep.py
+++ b/sgrep.py
@@ -30,11 +30,6 @@ from urllib.parse import urlparse
 import requests
 import yaml
 
-try:
-    from yaml import CLoader as Loader
-except ImportError:
-    from yaml import Loader
-
 # Constants
 
 TEMPLATE_YAML_URL = (

--- a/sgrep.py
+++ b/sgrep.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import time
 import base64
 import collections
 import itertools
@@ -28,6 +29,11 @@ from urllib.parse import urlparse
 
 import requests
 import yaml
+
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
 
 # Constants
 
@@ -183,7 +189,7 @@ def build_boolean_expression(rule):
     elif "patterns" in rule:  # multiple patterns at root
         yield from _parse_boolean_expression(rule["patterns"])
     else:
-        assert False
+        raise Exception(PLEASE_FILE_ISSUE_TEXT)
 
 
 def operator_for_pattern_name(pattern_name: str) -> str:
@@ -241,7 +247,9 @@ def _evaluate_single_expression(
         # print(f"after filter `{operator}`: {output_ranges}")
         return output_ranges
     else:
-        assert False, f"unknown operator {operator}"
+        raise NotImplementedError(
+            f"{PLEASE_FILE_ISSUE_TEXT}: unknown operator {operator}"
+        )
 
 
 def evaluate_expression(expression, results: Dict[str, List[Range]]) -> Set[Range]:
@@ -530,6 +538,7 @@ def download_config(config_url: str) -> Any:
 
 def resolve_config(config_str: Optional[str]) -> Any:
     """ resolves if config arg is a registry entry, a url, or a file, folder, or loads from defaults if None"""
+    start_t = time.time()
     if config_str is None:
         config = load_config()
     elif config_str in RULES_REGISTRY:
@@ -538,6 +547,7 @@ def resolve_config(config_str: Optional[str]) -> Any:
         config = download_config(config_str)
     else:
         config = load_config(config_str)
+    debug_print(f"loaded {len(config)} configs in {time.time() - start_t}")
     return config
 
 
@@ -828,9 +838,12 @@ def main(args: argparse.Namespace):
         valid_configs = rename_rule_ids(valid_configs)
 
     # now validate all the patterns inside the configs
-    invalid_patterns = validate_patterns(valid_configs)
-    if len(invalid_patterns):
-        print_error_exit("invalid patterns found inside rules; aborting")
+    if not args.skip_pattern_validation:
+        start_validate_t = time.time()
+        invalid_patterns = validate_patterns(valid_configs)
+        if len(invalid_patterns):
+            print_error_exit("invalid patterns found inside rules; aborting")
+        debug_print(f"debug: validated config in {time.time() - start_validate_t}")
 
     # extract just the rules from valid configs
     all_rules = flatten_configs(valid_configs)
@@ -846,7 +859,7 @@ def main(args: argparse.Namespace):
     # actually invoke sgrep
     start = datetime.now()
     output_json = invoke_sgrep(all_patterns, targets, strict)
-    debug_print(f"sgrep ran in {datetime.now() - start}")
+    print_error(f"sgrep ran in {datetime.now() - start}")
     debug_print(str(output_json))
 
     # group output; we want to see all of the same rule ids on the same file path
@@ -1007,6 +1020,11 @@ if __name__ == "__main__":
     output.add_argument(
         "--r2c",
         help="output json in r2c platform format (https://app.r2c.dev)",
+        action="store_true",
+    )
+    output.add_argument(
+        "--skip-pattern-validation",
+        help="skip using sgrep to validate patterns before running (not recommended)",
         action="store_true",
     )
     output.add_argument(

--- a/testlint/python/bad2.yaml
+++ b/testlint/python/bad2.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: eqeq-is-bad
+    pattern-inside: foo(...)
+    patterns:
+      - pattern-not: 1 == 1
+    message: "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
+    languages: [python]
+    severity: ERROR


### PR DESCRIPTION
We are incurring a almost 4 second penalty by validating the rules in --config=r2c; in this commit, we add a flag to skip that pattern validation.

We may want to automatically turn this flag on for our golden r2c config.