### PR TITLE
Normalize some formatting / capitalization in docs/patterns.md

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,6 +1,6 @@
 ## Example sgrep Patterns
 
-### expression Matching
+### Expression Matching
 
 ```
 pattern: 1 + foo(42)
@@ -10,7 +10,7 @@ pattern: 1 + foo(42)
 foobar(1 + foo(42)) + whatever()
 ```
 
-### metavariables
+### Metavariables
 
 ```
 pattern: $X + $Y
@@ -30,7 +30,7 @@ pattern: import $X
 import random
 ```
 
-Reusing Metavariables**
+**Reusing Metavariables**
 
 ```
 pattern: ￼$X == $X
@@ -85,7 +85,7 @@ pattern: $X.get(..., None)
 json_data.get('success', None)
 ```
 
-**Keyword Arguments in Any Order **
+**Keyword Arguments in Any Order**
 
 ```
 pattern: foo(kwd1=$X, err=$Y)
@@ -119,7 +119,7 @@ pattern: foo("=~/.*a.*/")
 foo("this has an a")
 ```
 
-### conditionals
+### Conditionals
 
 ```
 pattern: |


### PR DESCRIPTION
Just some small edits to normalize capitalization and a few places weren't bolded as intended.