### PR TITLE
guide user if repo not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,6 @@ ENV PYTHONUNBUFFERED=1
 
 COPY --from=build /home/opam/sgrep/_build/default/bin/main_sgrep.exe /bin/sgrep
 COPY --from=build /home/opam/sgrep/sgrep.py /bin/sgrep-lint
+
+ENV SGREP_IN_DOCKER=1
 ENTRYPOINT [ "/bin/sgrep-lint" ]

--- a/sgrep.py
+++ b/sgrep.py
@@ -36,7 +36,7 @@ TEMPLATE_YAML_URL = (
     "https://raw.githubusercontent.com/returntocorp/sgrep-rules/develop/template.yaml"
 )
 PLEASE_FILE_ISSUE_TEXT = "An error occurred while invoking the sgrep engine; please help us fix this by filing an an issue at https://sgrep.dev"
-IN_DOCKER = 'SGREP_IN_DOCKER' in os.environ
+IN_DOCKER = "SGREP_IN_DOCKER" in os.environ
 REPO_HOME_DOCKER = "/home/repo/"
 PRE_COMMIT_SRC_DOCKER = "/src"
 DEFAULT_SGREP_CONFIG_NAME = "sgrep"
@@ -401,8 +401,10 @@ def flatten_rule_patterns(all_rules):
 def adjust_for_docker():
     # change into this folder so that all paths are relative to it
     if IN_DOCKER:
-        if not Path(REPO_HOME_DOCKER).exists():        
-            print_error_exit(f'you are running sgrep in docker, but you forgot to mount the current directory in Docker: missing: -v $(pwd):{REPO_HOME_DOCKER}')
+        if not Path(REPO_HOME_DOCKER).exists():
+            print_error_exit(
+                f"you are running sgrep in docker, but you forgot to mount the current directory in Docker: missing: -v $(pwd):{REPO_HOME_DOCKER}"
+            )
         os.chdir(REPO_HOME_DOCKER)
     elif Path(PRE_COMMIT_SRC_DOCKER).exists():
         os.chdir(PRE_COMMIT_SRC_DOCKER)
@@ -500,10 +502,12 @@ def load_config(location: Optional[str] = None) -> Any:
             else:
                 print_error_exit(f"{loc} is not a file or folder!")
         else:
-            addendum = ''
+            addendum = ""
             if IN_DOCKER:
-                addendum = ' (since you are running in docker, you cannot specify arbitary paths on the host; they must be mounted into the container)'
-            print_error_exit(f"unable to find a config; path {loc} does not exist{addendum}")
+                addendum = " (since you are running in docker, you cannot specify arbitary paths on the host; they must be mounted into the container)"
+            print_error_exit(
+                f"unable to find a config; path {loc} does not exist{addendum}"
+            )
 
 
 def download_config(config_url: str) -> Any:


### PR DESCRIPTION
Helpfully prompt the user if running in docker and they specify a path to (a) a target file or (b) a config dir/file that doesn't exist

### code

BEFORE

```
ine@ ~/D/r/sgrep (feature/docker-error-messages)> docker run --rm returntocorp/sgrep -e '$X = $Y' data
running 1 rules from 1 yaml files (0 yaml files were invalid)
Fatal error: exception (Failure "fullpath: file (or directory) data does not exist")
non-zero return code while invoking sgrep with:
	sgrep -lang python -rules_file /tmp/tmpvoqzjszw data
Command '['sgrep', '-lang', 'python', '-rules_file', '/tmp/tmpvoqzjszw', 'data']' returned non-zero exit status 2.
```

AFTER

```
ine@ ~/D/r/sgrep (develop) [125]> docker run --rm sgrep-local -e '$X = $Y' data
you are running sgrep in docker, but you forgot to mount the current directory in Docker: look at the quickstart guide for the missing text: -v $(pwd):/home/repo/
```

### missing rules

```
ine@I ~/D/r/sgrep (feature/docker-error-messages)> docker run --rm -v (pwd):/home/repo  sgrep-local --config=/tmp/mine data
unable to find a config; path /tmp/mine does not exist (since you are running in docker, you cannot specify arbitary paths on the host; they must be mounted into the container)
```