### PR TITLE
pattern-where-python

### DIFF
--- a/sgrep.py
+++ b/sgrep.py
@@ -737,9 +737,9 @@ def validate_patterns(valid_configs: Dict[str, Any]) -> List[str]:
                 for language in rule["languages"]:
                     # avoid patterns that don't have pattern_ids, like pattern-either
                     if should_send_to_sgrep(expr) and not validate_pattern_with_sgrep(
-                        expr.operand, language # type: ignore
+                        expr.operand, language  # type: ignore
                     ):
-                        invalid.append(expr.operand) # type: ignore
+                        invalid.append(expr.operand)  # type: ignore
                         print_error(
                             f"in {config_id}, pattern in rule {rule['id']} can't be parsed for language {language}: {expr.operand}"
                         )

--- a/sgrep.py
+++ b/sgrep.py
@@ -280,7 +280,7 @@ def _evaluate_single_expression(
             # Only need to check where-python clause if the range hasn't already been filtered
 
             if sgrep_range.range in ranges_left:
-                print_error(
+                debug_print(
                     f"WHERE is {expression.operand}, metavars: {sgrep_range.metavars}"
                 )
                 if where_python_statement_matches(
@@ -319,7 +319,7 @@ def where_python_statement_matches(
         print_error_exit(
             f"python where expression needs boolean output but got: {output} for {where_expression}"
         )
-    return output
+    return output == True
 
 
 def evaluate_expression(
@@ -725,9 +725,7 @@ def validate_patterns(valid_configs: Dict[str, Any]) -> List[str]:
             )
             for expr in expressions:
                 for language in rule["languages"]:
-                    # if expr does not have a pattern id, it's not something that we will
-                    # actually send to sgrep
-                    if expr.pattern_id and not validate_pattern_with_sgrep(
+                    if expr.operand and not validate_pattern_with_sgrep(
                         expr.operand, language
                     ):
                         invalid.append(expr.operand)

--- a/sgrep.py
+++ b/sgrep.py
@@ -466,8 +466,8 @@ def should_send_to_sgrep(expression: BooleanRuleExpression) -> bool:
     don't send rules like "and-either" or "and-all" to sgrep
     """
     return (
-        expression.pattern_id
-        and expression.operand
+        expression.pattern_id is not None
+        and expression.operand is not None
         and (expression.operator != OPERATORS.WHERE_PYTHON)
     )
 
@@ -737,9 +737,9 @@ def validate_patterns(valid_configs: Dict[str, Any]) -> List[str]:
                 for language in rule["languages"]:
                     # avoid patterns that don't have pattern_ids, like pattern-either
                     if should_send_to_sgrep(expr) and not validate_pattern_with_sgrep(
-                        expr.operand, language
+                        expr.operand, language # type: ignore
                     ):
-                        invalid.append(expr.operand)
+                        invalid.append(expr.operand) # type: ignore
                         print_error(
                             f"in {config_id}, pattern in rule {rule['id']} can't be parsed for language {language}: {expr.operand}"
                         )

--- a/sgrep.py
+++ b/sgrep.py
@@ -12,7 +12,8 @@ import tarfile
 import tempfile
 import time
 import traceback
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from dataclasses import field
 from datetime import datetime
 from pathlib import Path
 from pathlib import PurePath
@@ -20,13 +21,14 @@ from typing import Any
 from typing import DefaultDict
 from typing import Dict
 from typing import Generator
-from typing import Iterable, Iterator
+from typing import Iterable
+from typing import Iterator
 from typing import List
+from typing import NewType
 from typing import Optional
 from typing import Set
 from typing import Tuple
 from urllib.parse import urlparse
-from typing import NewType
 
 PatternId = NewType("PatternId", str)
 Operator = NewType("Operator", str)
@@ -139,7 +141,7 @@ def flatten(L: Iterable[Iterable[Any]]) -> Iterable[Any]:
 
 
 def enumerate_patterns_in_boolean_expression(
-    expressions: Iterable[BooleanRuleExpression]
+    expressions: Iterable[BooleanRuleExpression],
 ) -> Iterable[BooleanRuleExpression]:
     """
     flatten a potentially nested expression
@@ -182,7 +184,7 @@ def _parse_boolean_expression(
 def build_boolean_expression(rule: Dict[str, Any]) -> Iterator[BooleanRuleExpression]:
     """
     Build a boolean expression from the yml lines in the rule
-    
+
     """
     if "pattern" in rule:  # single pattern at root
         yield BooleanRuleExpression(OPERATORS.AND, None, None, rule["pattern"])

--- a/sgrep.py
+++ b/sgrep.py
@@ -49,12 +49,44 @@ class OPERATORS:
     WHERE_PYTHON: Operator = Operator("where_python")
 
 
+OPERATORS_WITH_CHILDREN = [OPERATORS.AND_ALL, OPERATORS.AND_EITHER]
+
+
+class InvalidRuleSchema(BaseException):
+    pass
+
+
 @dataclass(frozen=True)
 class BooleanRuleExpression:
     operator: Operator
     pattern_id: Optional[PatternId] = None
     children: Optional[List["BooleanRuleExpression"]] = None
     operand: Optional[str] = None
+
+    def __post_init__(self):
+        self._validate()
+
+    def _validate(self):
+        if self.operator in set(OPERATORS_WITH_CHILDREN):
+            if self.operand is not None:
+                raise InvalidRuleSchema(
+                    f"operator `{pattern_name_for_operator(self.operator)}` cannot have operand but found {self.operand}"
+                )
+        else:
+            if self.children is not None:
+                raise InvalidRuleSchema(
+                    f"only {list(map(pattern_name_for_operator, OPERATORS_WITH_CHILDREN))} operators can have children, but found `{self.operator}` with children"
+                )
+
+            if self.operand is None:
+                raise InvalidRuleSchema(
+                    f"operator `{pattern_name_for_operator(self.operator)}` must have operand"
+                )
+            else:
+                if type(self.operand) != str:
+                    raise InvalidRuleSchema(
+                        f"operand of operator `{pattern_name_for_operator(self.operator)}` ought to have type string, but is {type(self.operand)}: {self.operand}"
+                    )
 
 
 # Constants
@@ -180,7 +212,7 @@ def _parse_boolean_expression(
                 )
                 pattern_id += 1
             else:
-                raise TypeError(
+                raise InvalidRuleSchema(
                     f"invalid type for pattern {pattern}: {type(pattern_text)}"
                 )
 
@@ -195,13 +227,13 @@ def build_boolean_expression(rule: Dict[str, Any]) -> Iterator[BooleanRuleExpres
     elif "patterns" in rule:  # multiple patterns at root
         yield from _parse_boolean_expression(rule["patterns"])
     else:
-        raise Exception(PLEASE_FILE_ISSUE_TEXT)
+        print_error_exit(f"unknown operator in rule {rule}: {PLEASE_FILE_ISSUE_TEXT}")
 
 
 def operator_for_pattern_name(pattern_name: str) -> Operator:
     if not pattern_name in PATTERN_NAMES_MAP:
         print_error_exit(
-            f"invalid pattern name: {pattern_name}, valid pattern names are {list(PATTERN_NAMES_MAP.keys())}"
+            f"invalid pattern name: {pattern_name}, valid pattern names are {list(PATTERN_NAMES_MAP.keys())}: {PLEASE_FILE_ISSUE_TEXT}"
         )
     return PATTERN_NAMES_MAP[pattern_name]
 
@@ -297,9 +329,10 @@ def _evaluate_single_expression(
         return output_ranges
 
     else:
-        raise NotImplementedError(
+        print_error_exit(
             f"{PLEASE_FILE_ISSUE_TEXT}: unknown operator {expression.operator}"
         )
+        assert False  # for mypy
 
 
 # Given a `where-python` expression as a string and currently matched metavars,
@@ -491,7 +524,7 @@ def should_send_to_sgrep(expression: BooleanRuleExpression) -> bool:
     )
 
 
-def flatten_rule_patterns(all_rules):
+def flatten_rule_patterns(all_rules) -> Iterator[Dict[str, Any]]:
     for rule_index, rule in enumerate(all_rules):
         flat_expressions = list(
             enumerate_patterns_in_boolean_expression(
@@ -666,6 +699,39 @@ def resolve_config(config_str: Optional[str]) -> Any:
     return config
 
 
+def validate_single_rule(config_id: str, rule_index: int, rule: Dict[str, Any]) -> bool:
+    rule_id_err_msg = f'(rule id: {rule.get("id", MISSING_RULE_ID)})'
+    if not set(rule.keys()).issuperset(MUST_HAVE_KEYS):
+        print_error(
+            f"{config_id} is missing keys at rule {rule_index+1} {rule_id_err_msg}, must have: {MUST_HAVE_KEYS}"
+        )
+        return False
+    if not set(rule.keys()).issubset(ALL_VALID_RULE_KEYS):
+        print_error(
+            f"{config_id} has invalid rule key at rule {rule_index+1} {rule_id_err_msg}, can only have: {ALL_VALID_RULE_KEYS}"
+        )
+        return False
+    if not "pattern" in rule and not "patterns" in rule:
+        print_error(
+            f"{config_id} is missing key `pattern` or `patterns` at rule {rule_index+1} {rule_id_err_msg}"
+        )
+        return False
+    if "patterns" in rule and not rule["patterns"]:
+        print_error(
+            f"{config_id} no patterns found inside rule {rule_index+1} {rule_id_err_msg}"
+        )
+        return False
+    try:
+        _ = list(build_boolean_expression(rule))
+    except InvalidRuleSchema as ex:
+        print_error(
+            f"{config_id}: inside rule {rule_index+1} {rule_id_err_msg}, pattern fields can't look like this: {ex}"
+        )
+        return False
+
+    return True
+
+
 def validate_configs(configs: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """ Take configs and separate into valid and invalid ones"""
 
@@ -683,33 +749,10 @@ def validate_configs(configs: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str,
         valid_rules = []
         invalid_rules = []
         for i, rule in enumerate(rules):
-            rule_id_err_msg = f'(rule id: {rule.get("id", MISSING_RULE_ID)})'
-            if not set(rule.keys()).issuperset(MUST_HAVE_KEYS):
-                print_error(
-                    f"{config_id} is missing keys at rule {i+1} {rule_id_err_msg}, must have: {MUST_HAVE_KEYS}"
-                )
+            if validate_single_rule(config_id, i, rule):
+                valid_rules.append(rule)
+            else:
                 invalid_rules.append(rule)
-                continue
-            if not set(rule.keys()).issubset(ALL_VALID_RULE_KEYS):
-                print_error(
-                    f"{config_id} has invalid rule key at rule {i+1} {rule_id_err_msg}, can only have: {ALL_VALID_RULE_KEYS}"
-                )
-                invalid_rules.append(rule)
-                continue
-            if not "pattern" in rule and not "patterns" in rule:
-                print_error(
-                    f"{config_id} is missing key `pattern` or `patterns` at rule {i+1} {rule_id_err_msg}"
-                )
-                invalid_rules.append(rule)
-                continue
-            if "patterns" in rule and not rule["patterns"]:
-                print_error(
-                    f"{config_id} no patterns found inside rule {i+1} {rule_id_err_msg}"
-                )
-                invalid_rules.append(rule)
-                continue
-
-            valid_rules.append(rule)
 
         if invalid_rules:
             errors[config_id] = {**config, "rules": invalid_rules}
@@ -747,10 +790,8 @@ def validate_patterns(valid_configs: Dict[str, Any]) -> List[str]:
     for config_id, config in valid_configs.items():
         rules = config.get(RULES_KEY, [])
         for rule in rules:
-            expressions = list(
-                enumerate_patterns_in_boolean_expression(
-                    list(build_boolean_expression(rule))
-                )
+            expressions = enumerate_patterns_in_boolean_expression(
+                build_boolean_expression(rule)
             )
             for expr in expressions:
                 for language in rule["languages"]:

--- a/sgrep.py
+++ b/sgrep.py
@@ -187,7 +187,7 @@ def build_boolean_expression(rule: Dict[str, Any]) -> Iterator[BooleanRuleExpres
 
     """
     if "pattern" in rule:  # single pattern at root
-        yield BooleanRuleExpression(OPERATORS.AND, None, None, rule["pattern"])
+        yield BooleanRuleExpression(OPERATORS.AND, rule["id"], None, rule["pattern"])
     elif "patterns" in rule:  # multiple patterns at root
         yield from _parse_boolean_expression(rule["patterns"])
     else:

--- a/sgrep.py
+++ b/sgrep.py
@@ -276,7 +276,7 @@ def _evaluate_single_expression(
     elif expression.operator == OPERATORS.WHERE_PYTHON:
         if not RCE_RULE_FLAG not in flags:
             print_error_exit(
-                f"at least one rule needs to execute arbitrary code; this is dangerous! if you want to continue, enable the flag: RCE_RULE_FLAG"
+                f"at least one rule needs to execute arbitrary code; this is dangerous! if you want to continue, enable the flag: {RCE_RULE_FLAG}"
             )
         assert expression.operand, "must have operand for this operator type"
 

--- a/testlint/python/bad3.yaml
+++ b/testlint/python/bad3.yaml
@@ -1,0 +1,7 @@
+rules:
+  - id: test-pattern
+    pattern:
+        - pattern: "$D = {}"
+    message: "test"
+    languages: [python]
+    severity: WARNING

--- a/testlint/run-lint-tests.sh
+++ b/testlint/run-lint-tests.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$(realpath "$0")")";
 PYTHONPATH=.. python3 test_lint.py
 
 cd ..
-./sgrep.py --json --strict --config testlint/python/eqeq.yaml tests/lint -o tmp.out
+./sgrep.py --json --strict --config testlint/python/eqeq.yaml tests/lint -o tmp.out >/dev/null
 diff tmp.out ./testlint/python/eqeq.expected.json
 rm -f tmp.out
 
@@ -15,6 +15,9 @@ rm -f tmp.out
 
 # parsing bad2.yaml should fail 
 ./sgrep.py --strict --config testlint/python/bad2.yaml tests/lint && echo "bad2.yaml should have failed" && exit 1
+
+# parsing bad3.yaml should fail 
+./sgrep.py --strict --config testlint/python/bad3.yaml tests/lint && echo "bad3.yaml should have failed" && exit 1
 
 
 echo "-----------------------"

--- a/testlint/test_lint.py
+++ b/testlint/test_lint.py
@@ -12,6 +12,8 @@ from sgrep import (
 
 # run from parent directory with PYTHONPATH=. python3 testlint/test_lint.py
 
+def SRange(start:int, end: int):
+    return SgrepRange(Range(start,end), {})
 
 def testA():
     """
@@ -32,8 +34,8 @@ def testA():
 
     """
     results = {
-        "pattern1": [Range(30, 100)],
-        "pattern2": [Range(0, 100), Range(30, 100)],
+        "pattern1": [SRange(30, 100)],
+        "pattern2": [SRange(0, 100), SRange(30, 100)],
     }
     expression = [(OPERATORS.AND_NOT, "pattern1"), (OPERATORS.AND, "pattern2")]
     result = evaluate_expression(expression, results)
@@ -61,8 +63,8 @@ def testB():
         OUTPUT: R2
     """
     results = {
-        "pattern1": [Range(0, 100)],
-        "pattern2": [Range(30, 70), Range(0, 100)],
+        "pattern1": [SRange(0, 100)],
+        "pattern2": [SRange(30, 70), SRange(0, 100)],
         "pattern3": [],
     }
     expression = [
@@ -95,9 +97,9 @@ def testC():
         OUTPUT: R2
     """
     results = {
-        "pattern1": [Range(100, 1000)],
-        "pattern2": [Range(100, 1000), Range(200, 300)],
-        "pattern4": [Range(0, 1000)],
+        "pattern1": [SRange(100, 1000)],
+        "pattern2": [SRange(100, 1000), SRange(200, 300)],
+        "pattern4": [SRange(0, 1000)],
     }
     expression = [
         (OPERATORS.AND_INSIDE, "pattern4"),
@@ -127,9 +129,9 @@ def testD():
         OUTPUT: []
     """
     results = {
-        "pattern1": [Range(100, 1000)],
-        "pattern2": [Range(100, 1000), Range(200, 300)],
-        "pattern4": [Range(0, 1000)],
+        "pattern1": [SRange(100, 1000)],
+        "pattern2": [SRange(100, 1000), SRange(200, 300)],
+        "pattern4": [SRange(0, 1000)],
     }
     expression = [
         (OPERATORS.AND_NOT_INSIDE, "pattern4"),
@@ -164,13 +166,13 @@ def testE():
     """
     results = {
         "pattern1": [
-            Range(100, 200),
-            Range(300, 400),
-            Range(350, 400),
-            Range(500, 600),
+            SRange(100, 200),
+            SRange(300, 400),
+            SRange(350, 400),
+            SRange(500, 600),
         ],
-        "pattern2": [Range(0, 200), Range(400, 600)],
-        "pattern3": [Range(200, 600)],
+        "pattern2": [SRange(0, 200), SRange(400, 600)],
+        "pattern3": [SRange(200, 600)],
     }
     expression = [
         (OPERATORS.AND_INSIDE, "pattern3"),
@@ -254,10 +256,10 @@ def testF():
         OUTPUT: [500-600], [700-800]
     """
     results = {
-        "pattern1": [Range(100, 200), Range(400, 500), Range(700, 800)],
-        "pattern2": [Range(200, 300), Range(500, 600), Range(800, 900)],
-        "pattern3": [Range(0, 900)],
-        "pattern4": [Range(300, 600)],
+        "pattern1": [SRange(100, 200), SRange(400, 500), SRange(700, 800)],
+        "pattern2": [SRange(200, 300), SRange(500, 600), SRange(800, 900)],
+        "pattern3": [SRange(0, 900)],
+        "pattern4": [SRange(300, 600)],
     }
 
     subexpression1 = [(OPERATORS.AND_INSIDE, "pattern4"), (OPERATORS.AND, "pattern2")]

--- a/testlint/test_lint.py
+++ b/testlint/test_lint.py
@@ -1,8 +1,10 @@
 import os
+from typing import List
 import sys
 
 from sgrep import (
     OPERATORS,
+    Operator,
     Range,
     evaluate_expression,
     enumerate_patterns_in_boolean_expression,
@@ -15,6 +17,9 @@ from sgrep import (
 
 def SRange(start: int, end: int):
     return SgrepRange(Range(start, end), {})
+
+def RuleExpr(operator: Operator, fake_pattern_name: str, children: List[BooleanRuleExpression]=None):
+    return BooleanRuleExpression(operator, fake_pattern_name, children, "fake-pattern-text-here")
 
 
 def testA():
@@ -40,8 +45,8 @@ def testA():
         "pattern2": [SRange(0, 100), SRange(30, 100)],
     }
     expression = [
-        BooleanRuleExpression(OPERATORS.AND_NOT, "pattern1"),
-        BooleanRuleExpression(OPERATORS.AND, "pattern2"),
+        RuleExpr(OPERATORS.AND_NOT, "pattern1"),
+        RuleExpr(OPERATORS.AND, "pattern2"),
     ]
     result = evaluate_expression(expression, results)
     assert result == set([Range(0, 100)]), f"{result}"
@@ -73,13 +78,13 @@ def testB():
         "pattern3": [],
     }
     expression = [
-        BooleanRuleExpression(OPERATORS.AND_NOT, "pattern1"),
+        RuleExpr(OPERATORS.AND_NOT, "pattern1"),
         BooleanRuleExpression(
             OPERATORS.AND_EITHER,
             None,
             [
-                BooleanRuleExpression(OPERATORS.AND, "pattern2"),
-                BooleanRuleExpression(OPERATORS.AND, "pattern3"),
+                RuleExpr(OPERATORS.AND, "pattern2"),
+                RuleExpr(OPERATORS.AND, "pattern3"),
             ],
         ),
     ]
@@ -111,9 +116,9 @@ def testC():
         "pattern4": [SRange(0, 1000)],
     }
     expression = [
-        BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern4"),
-        BooleanRuleExpression(OPERATORS.AND_NOT, "pattern1"),
-        BooleanRuleExpression(OPERATORS.AND, "pattern2"),
+        RuleExpr(OPERATORS.AND_INSIDE, "pattern4"),
+        RuleExpr(OPERATORS.AND_NOT, "pattern1"),
+        RuleExpr(OPERATORS.AND, "pattern2"),
     ]
     result = evaluate_expression(expression, results)
     assert result == set([Range(200, 300)]), f"{result}"
@@ -143,9 +148,9 @@ def testD():
         "pattern4": [SRange(0, 1000)],
     }
     expression = [
-        BooleanRuleExpression(OPERATORS.AND_NOT_INSIDE, "pattern4"),
-        BooleanRuleExpression(OPERATORS.AND_NOT, "pattern1"),
-        BooleanRuleExpression(OPERATORS.AND, "pattern2"),
+        RuleExpr(OPERATORS.AND_NOT_INSIDE, "pattern4"),
+        RuleExpr(OPERATORS.AND_NOT, "pattern1"),
+        RuleExpr(OPERATORS.AND, "pattern2"),
     ]
     result = evaluate_expression(expression, results)
     assert result == set([]), f"{result}"
@@ -184,9 +189,9 @@ def testE():
         "pattern3": [SRange(200, 600)],
     }
     expression = [
-        BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern3"),
-        BooleanRuleExpression(OPERATORS.AND_NOT_INSIDE, "pattern2"),
-        BooleanRuleExpression(OPERATORS.AND, "pattern1"),
+        RuleExpr(OPERATORS.AND_INSIDE, "pattern3"),
+        RuleExpr(OPERATORS.AND_NOT_INSIDE, "pattern2"),
+        RuleExpr(OPERATORS.AND, "pattern1"),
     ]
     result = evaluate_expression(expression, results)
     assert result == set([Range(300, 400), Range(350, 400)]), f"{result}"
@@ -198,9 +203,9 @@ def testE():
         OUTPUT: [100-200]
     """
     expression = [
-        BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern2"),
-        BooleanRuleExpression(OPERATORS.AND_NOT_INSIDE, "pattern3"),
-        BooleanRuleExpression(OPERATORS.AND, "pattern1"),
+        RuleExpr(OPERATORS.AND_INSIDE, "pattern2"),
+        RuleExpr(OPERATORS.AND_NOT_INSIDE, "pattern3"),
+        RuleExpr(OPERATORS.AND, "pattern1"),
     ]
     result = evaluate_expression(expression, results)
     assert result == set([Range(100, 200)]), f"{result}"
@@ -209,7 +214,7 @@ def testE():
         and-inside P1
         OUTPUT: [100-200, 300-400, 350-400, 500-600]
     """
-    expression = [BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern1")]
+    expression = [RuleExpr(OPERATORS.AND_INSIDE, "pattern1")]
     result = evaluate_expression(expression, results)
     assert result == set(
         [Range(100, 200), Range(300, 400), Range(350, 400), Range(500, 600)]
@@ -272,15 +277,15 @@ def testF():
     }
 
     subexpression1 = [
-        BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern4"),
-        BooleanRuleExpression(OPERATORS.AND, "pattern2"),
+        RuleExpr(OPERATORS.AND_INSIDE, "pattern4"),
+        RuleExpr(OPERATORS.AND, "pattern2"),
     ]
     subexpression2 = [
-        BooleanRuleExpression(OPERATORS.AND_NOT_INSIDE, "pattern4"),
-        BooleanRuleExpression(OPERATORS.AND, "pattern1"),
+        RuleExpr(OPERATORS.AND_NOT_INSIDE, "pattern4"),
+        RuleExpr(OPERATORS.AND, "pattern1"),
     ]
     expression = [
-        BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern3"),
+        RuleExpr(OPERATORS.AND_INSIDE, "pattern3"),
         BooleanRuleExpression(
             OPERATORS.AND_EITHER,
             None,
@@ -379,7 +384,7 @@ def testEvaluatePython():
     }
 
     expression = [
-        BooleanRuleExpression(OPERATORS.AND, "all_execs"),
+        BooleanRuleExpression(OPERATORS.AND, "all_execs", None, "all_execs"),
         BooleanRuleExpression(
             OPERATORS.WHERE_PYTHON, "p1", None, "vars['$X'].startswith('cmd')"
         ),

--- a/testlint/test_lint.py
+++ b/testlint/test_lint.py
@@ -7,15 +7,15 @@ from sgrep import (
     evaluate_expression,
     enumerate_patterns_in_boolean_expression,
     SgrepRange,
-    BooleanRuleExpression
+    BooleanRuleExpression,
 )
 
 # run from parent directory with PYTHONPATH=. python3 testlint/test_lint.py
 
-def SRange(start:int, end: int):
-    return SgrepRange(Range(start,end), {})
 
-    
+def SRange(start: int, end: int):
+    return SgrepRange(Range(start, end), {})
+
 
 def testA():
     """
@@ -39,7 +39,10 @@ def testA():
         "pattern1": [SRange(30, 100)],
         "pattern2": [SRange(0, 100), SRange(30, 100)],
     }
-    expression = [BooleanRuleExpression(OPERATORS.AND_NOT, "pattern1"), BooleanRuleExpression(OPERATORS.AND, "pattern2")]
+    expression = [
+        BooleanRuleExpression(OPERATORS.AND_NOT, "pattern1"),
+        BooleanRuleExpression(OPERATORS.AND, "pattern2"),
+    ]
     result = evaluate_expression(expression, results)
     assert result == set([Range(0, 100)]), f"{result}"
 
@@ -72,8 +75,12 @@ def testB():
     expression = [
         BooleanRuleExpression(OPERATORS.AND_NOT, "pattern1"),
         BooleanRuleExpression(
-            OPERATORS.AND_EITHER, None,
-            [BooleanRuleExpression(OPERATORS.AND, "pattern2"), BooleanRuleExpression(OPERATORS.AND, "pattern3")],
+            OPERATORS.AND_EITHER,
+            None,
+            [
+                BooleanRuleExpression(OPERATORS.AND, "pattern2"),
+                BooleanRuleExpression(OPERATORS.AND, "pattern3"),
+            ],
         ),
     ]
     result = evaluate_expression(expression, results)
@@ -193,7 +200,7 @@ def testE():
     expression = [
         BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern2"),
         BooleanRuleExpression(OPERATORS.AND_NOT_INSIDE, "pattern3"),
-       BooleanRuleExpression(OPERATORS.AND, "pattern1"),
+        BooleanRuleExpression(OPERATORS.AND, "pattern1"),
     ]
     result = evaluate_expression(expression, results)
     assert result == set([Range(100, 200)]), f"{result}"
@@ -264,7 +271,10 @@ def testF():
         "pattern4": [SRange(300, 600)],
     }
 
-    subexpression1 = [BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern4"), BooleanRuleExpression(OPERATORS.AND, "pattern2")]
+    subexpression1 = [
+        BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern4"),
+        BooleanRuleExpression(OPERATORS.AND, "pattern2"),
+    ]
     subexpression2 = [
         BooleanRuleExpression(OPERATORS.AND_NOT_INSIDE, "pattern4"),
         BooleanRuleExpression(OPERATORS.AND, "pattern1"),
@@ -272,8 +282,12 @@ def testF():
     expression = [
         BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern3"),
         BooleanRuleExpression(
-            OPERATORS.AND_EITHER, None,
-            [BooleanRuleExpression(OPERATORS.AND_ALL, None, subexpression1), BooleanRuleExpression(OPERATORS.AND_ALL, None, subexpression2)],
+            OPERATORS.AND_EITHER,
+            None,
+            [
+                BooleanRuleExpression(OPERATORS.AND_ALL, None, subexpression1),
+                BooleanRuleExpression(OPERATORS.AND_ALL, None, subexpression2),
+            ],
         ),
     ]
     result = evaluate_expression(expression, results)
@@ -320,6 +334,7 @@ def test_exprs():
 
     assert flat == expected, f"flat: {flat}"
 
+
 def testEvaluatePython():
     """Test evaluating the subpattern `where-python: <python_expression>`,
     in which a rule can provide an arbitrary Python expression that will be
@@ -357,19 +372,22 @@ def testEvaluatePython():
         OUTPUT: [400-500]
     """
     results = {
-        "all_execs": [SgrepRange(Range(400, 500), {"$X": "cmd_pattern"}), 
-                      SgrepRange(Range(800, 900), {"$X": "other_pattern"})],
+        "all_execs": [
+            SgrepRange(Range(400, 500), {"$X": "cmd_pattern"}),
+            SgrepRange(Range(800, 900), {"$X": "other_pattern"}),
+        ]
     }
 
     expression = [
         BooleanRuleExpression(OPERATORS.AND, "all_execs"),
-        BooleanRuleExpression(OPERATORS.WHERE_PYTHON, "p1", None, "vars['$X'].startswith('cmd')"),
+        BooleanRuleExpression(
+            OPERATORS.WHERE_PYTHON, "p1", None, "vars['$X'].startswith('cmd')"
+        ),
     ]
 
     result = evaluate_expression(expression, results)
-    assert result == set(
-        [Range(400, 500)]
-    ), f"{result}"
+    assert result == set([Range(400, 500)]), f"{result}"
+
 
 def testAll():
     testEvaluatePython()
@@ -381,7 +399,7 @@ def testAll():
     testD()
     testE()
     testF()
-    
+
 
 if __name__ == "__main__":
     testAll()


### PR DESCRIPTION
cc @clintgibler

tests in https://github.com/returntocorp/sgrep-rules/pull/185 and https://github.com/returntocorp/sgrep-rules/pull/196

when complete, closes #101 ; see https://github.com/returntocorp/sgrep/pull/166 for prior discussion

Major changes include using proper types and classes for the sgrep output as well as `BooleanRuleExpression` for the formerly-tuple parsed expressions.

Because of the potential for arbitrary code execution, these rules are only run if the command-line flag `--dangerously-allow-arbitrary-code-execution-from-rules` is set