### PR TITLE
remove python as default language for patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ docker run --rm -v $(pwd):/home/repo returntocorp/sgrep
 To rapidly iterate on a single pattern, you can test on a single file or folder. For example,
 
 ```bash
-docker run --rm -v $(pwd):/home/repo returntocorp/sgrep -e '$X == $X' path/to/file.py
+docker run --rm -v $(pwd):/home/repo returntocorp/sgrep -l python -e '$X == $X' path/to/file.py
 ```
 
 Here, `sgrep` will search the target with the pattern `$X == $X` (which is a stupid equals check) and print the results to `stdout`. This also works for directories and will skip the file if parsing fails. You can specifiy the language of the pattern with `--lang javascript` for example.

--- a/bin/main_sgrep.ml
+++ b/bin/main_sgrep.ml
@@ -51,7 +51,7 @@ let pattern_file = ref ""
 let rules_file = ref ""
 
 (* todo: infer from basename argv(0) ? *)
-let lang = ref "python"
+let lang = ref "unset"
 
 let case_sensitive = ref false
 let match_format = ref Matching_report.Normal
@@ -413,7 +413,7 @@ let all_actions () = [
 let options () = 
   [
     "-lang", Arg.Set_string lang, 
-    (spf " <str> choose language (default = %s)" !lang);
+    (spf " <str> choose language");
 
     "-e", Arg.Set_string pattern_string, 
     " <pattern> expression pattern";

--- a/sgrep.py
+++ b/sgrep.py
@@ -41,7 +41,6 @@ PRE_COMMIT_SRC_DOCKER = "/src"
 DEFAULT_SGREP_CONFIG_NAME = "sgrep"
 DEFAULT_CONFIG_FILE = f".{DEFAULT_SGREP_CONFIG_NAME}.yml"
 DEFAULT_CONFIG_FOLDER = f".{DEFAULT_SGREP_CONFIG_NAME}"
-DEFAULT_LANG = "python"
 
 MISSING_RULE_ID = "no-rule-id"
 
@@ -677,7 +676,7 @@ def manual_config(pattern: str, lang: str) -> Dict[str, Any]:
                 {
                     ID_KEY: "-",
                     "pattern": pattern,
-                    "message": f"{pattern}",
+                    "message": pattern,
                     "languages": [lang],
                     "severity": "ERROR",
                 }
@@ -794,10 +793,9 @@ def main(args: argparse.Namespace):
     # let's check for a pattern
     elif args.pattern:
         # and a language
-        if args.lang:
-            lang = args.lang
-        else:
-            lang = DEFAULT_LANG
+        if not args.lang:
+            print_error_exit('language must be specified when a pattern is passed')
+        lang = args.lang
         pattern = args.pattern
 
         # TODO for now we generate a manual config. Might want to just call sgrep -e ... -l ...
@@ -1052,7 +1050,7 @@ if __name__ == "__main__":
 
     ### Parse and validate
     args = parser.parse_args()
-    if args.lang and not args.pattern:
-        parser.error("-e/--pattern is required when -l/--lang is used.")
+    if args.lang and not args.pattern or (args.pattern and not args.lang):
+        parser.error("-e/--pattern and -l/--lang must both be specified")
 
     main(args)

--- a/sgrep.py
+++ b/sgrep.py
@@ -794,7 +794,7 @@ def main(args: argparse.Namespace):
     elif args.pattern:
         # and a language
         if not args.lang:
-            print_error_exit('language must be specified when a pattern is passed')
+            print_error_exit("language must be specified when a pattern is passed")
         lang = args.lang
         pattern = args.pattern
 


### PR DESCRIPTION
Closes https://github.com/returntocorp/sgrep/issues/161

Requires https://github.com/returntocorp/pfff/pull/36

And now:
``` 
sgrep --help
  -lang                     <str> choose language (valid choices: c, go, golang, java, javascript, js, ml, ocaml, py, python)
...
```