### PR TITLE
clearer error messages for invalid YAML files

### DIFF
--- a/sgrep.py
+++ b/sgrep.py
@@ -332,6 +332,7 @@ def _evaluate_single_expression(
         print_error_exit(
             f"{PLEASE_FILE_ISSUE_TEXT}: unknown operator {expression.operator}"
         )
+        return None  # for mypy
 
 
 # Given a `where-python` expression as a string and currently matched metavars,
@@ -523,7 +524,7 @@ def should_send_to_sgrep(expression: BooleanRuleExpression) -> bool:
     )
 
 
-def flatten_rule_patterns(all_rules) -> List[Dict[str, Any]]:
+def flatten_rule_patterns(all_rules) -> Iterator[Dict[str, Any]]:
     for rule_index, rule in enumerate(all_rules):
         flat_expressions = list(
             enumerate_patterns_in_boolean_expression(

--- a/sgrep.py
+++ b/sgrep.py
@@ -48,10 +48,13 @@ class OPERATORS:
     AND_NOT_INSIDE: Operator = Operator("and_not_inside")
     WHERE_PYTHON: Operator = Operator("where_python")
 
+
 OPERATORS_WITH_CHILDREN = [OPERATORS.AND_ALL, OPERATORS.AND_EITHER]
+
 
 class InvalidRuleSchema(BaseException):
     pass
+
 
 @dataclass(frozen=True)
 class BooleanRuleExpression:
@@ -66,16 +69,25 @@ class BooleanRuleExpression:
     def _validate(self):
         if self.operator in set(OPERATORS_WITH_CHILDREN):
             if self.operand is not None:
-                raise InvalidRuleSchema(f"operator `{pattern_name_for_operator(self.operator)}` cannot have operand but found {self.operand}")
-        else: 
+                raise InvalidRuleSchema(
+                    f"operator `{pattern_name_for_operator(self.operator)}` cannot have operand but found {self.operand}"
+                )
+        else:
             if self.children is not None:
-                raise InvalidRuleSchema(f"only {list(map(pattern_name_for_operator, OPERATORS_WITH_CHILDREN))} operators can have children, but found `{self.operator}` with children")
-            
+                raise InvalidRuleSchema(
+                    f"only {list(map(pattern_name_for_operator, OPERATORS_WITH_CHILDREN))} operators can have children, but found `{self.operator}` with children"
+                )
+
             if self.operand is None:
-                raise InvalidRuleSchema(f"operator `{pattern_name_for_operator(self.operator)}` must have operand")
+                raise InvalidRuleSchema(
+                    f"operator `{pattern_name_for_operator(self.operator)}` must have operand"
+                )
             else:
                 if type(self.operand) != str:
-                    raise InvalidRuleSchema(f"operand of operator `{pattern_name_for_operator(self.operator)}` ought to have type string, but is {type(self.operand)}: {self.operand}")
+                    raise InvalidRuleSchema(
+                        f"operand of operator `{pattern_name_for_operator(self.operator)}` ought to have type string, but is {type(self.operand)}: {self.operand}"
+                    )
+
 
 # Constants
 
@@ -685,6 +697,7 @@ def resolve_config(config_str: Optional[str]) -> Any:
         debug_print(f"loaded {len(config)} configs in {time.time() - start_t}")
     return config
 
+
 def validate_single_rule(config_id: str, rule_index: int, rule: Dict[str, Any]) -> bool:
     rule_id_err_msg = f'(rule id: {rule.get("id", MISSING_RULE_ID)})'
     if not set(rule.keys()).issuperset(MUST_HAVE_KEYS):
@@ -710,11 +723,13 @@ def validate_single_rule(config_id: str, rule_index: int, rule: Dict[str, Any]) 
     try:
         _ = list(build_boolean_expression(rule))
     except InvalidRuleSchema as ex:
-        print_error(f"{config_id}: inside rule {rule_index+1} {rule_id_err_msg}, pattern fields can't look like this: {ex}")
+        print_error(
+            f"{config_id}: inside rule {rule_index+1} {rule_id_err_msg}, pattern fields can't look like this: {ex}"
+        )
         return False
 
     return True
-        
+
 
 def validate_configs(configs: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """ Take configs and separate into valid and invalid ones"""
@@ -774,7 +789,9 @@ def validate_patterns(valid_configs: Dict[str, Any]) -> List[str]:
     for config_id, config in valid_configs.items():
         rules = config.get(RULES_KEY, [])
         for rule in rules:
-            expressions = enumerate_patterns_in_boolean_expression(build_boolean_expression(rule))
+            expressions = enumerate_patterns_in_boolean_expression(
+                build_boolean_expression(rule)
+            )
             for expr in expressions:
                 for language in rule["languages"]:
                     # avoid patterns that don't have pattern_ids, like pattern-either

--- a/sgrep.py
+++ b/sgrep.py
@@ -332,7 +332,7 @@ def _evaluate_single_expression(
         print_error_exit(
             f"{PLEASE_FILE_ISSUE_TEXT}: unknown operator {expression.operator}"
         )
-        return None  # for mypy
+        assert False  # for mypy
 
 
 # Given a `where-python` expression as a string and currently matched metavars,

--- a/testlint/python/bad3.yaml
+++ b/testlint/python/bad3.yaml
@@ -1,0 +1,7 @@
+rules:
+  - id: test-pattern
+    pattern:
+        - pattern: "$D = {}"
+    message: "test"
+    languages: [python]
+    severity: WARNING

--- a/testlint/run-lint-tests.sh
+++ b/testlint/run-lint-tests.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$(realpath "$0")")";
 PYTHONPATH=.. python3 test_lint.py
 
 cd ..
-./sgrep.py --json --strict --config testlint/python/eqeq.yaml tests/lint -o tmp.out
+./sgrep.py --json --strict --config testlint/python/eqeq.yaml tests/lint -o tmp.out >/dev/null
 diff tmp.out ./testlint/python/eqeq.expected.json
 rm -f tmp.out
 
@@ -15,6 +15,9 @@ rm -f tmp.out
 
 # parsing bad2.yaml should fail 
 ./sgrep.py --strict --config testlint/python/bad2.yaml tests/lint && echo "bad2.yaml should have failed" && exit 1
+
+# parsing bad3.yaml should fail 
+./sgrep.py --strict --config testlint/python/bad3.yaml tests/lint && echo "bad3.yaml should have failed" && exit 1
 
 
 echo "-----------------------"

--- a/testlint/test_lint.py
+++ b/testlint/test_lint.py
@@ -1,8 +1,10 @@
 import os
+from typing import List
 import sys
 
 from sgrep import (
     OPERATORS,
+    Operator,
     Range,
     evaluate_expression,
     enumerate_patterns_in_boolean_expression,
@@ -15,6 +17,9 @@ from sgrep import (
 
 def SRange(start: int, end: int):
     return SgrepRange(Range(start, end), {})
+
+def RuleExpr(operator: Operator, fake_pattern_name: str, children: List[BooleanRuleExpression]=None):
+    return BooleanRuleExpression(operator, fake_pattern_name, children, "fake-pattern-text-here")
 
 
 def testA():
@@ -40,8 +45,8 @@ def testA():
         "pattern2": [SRange(0, 100), SRange(30, 100)],
     }
     expression = [
-        BooleanRuleExpression(OPERATORS.AND_NOT, "pattern1"),
-        BooleanRuleExpression(OPERATORS.AND, "pattern2"),
+        RuleExpr(OPERATORS.AND_NOT, "pattern1"),
+        RuleExpr(OPERATORS.AND, "pattern2"),
     ]
     result = evaluate_expression(expression, results)
     assert result == set([Range(0, 100)]), f"{result}"
@@ -73,13 +78,13 @@ def testB():
         "pattern3": [],
     }
     expression = [
-        BooleanRuleExpression(OPERATORS.AND_NOT, "pattern1"),
+        RuleExpr(OPERATORS.AND_NOT, "pattern1"),
         BooleanRuleExpression(
             OPERATORS.AND_EITHER,
             None,
             [
-                BooleanRuleExpression(OPERATORS.AND, "pattern2"),
-                BooleanRuleExpression(OPERATORS.AND, "pattern3"),
+                RuleExpr(OPERATORS.AND, "pattern2"),
+                RuleExpr(OPERATORS.AND, "pattern3"),
             ],
         ),
     ]
@@ -111,9 +116,9 @@ def testC():
         "pattern4": [SRange(0, 1000)],
     }
     expression = [
-        BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern4"),
-        BooleanRuleExpression(OPERATORS.AND_NOT, "pattern1"),
-        BooleanRuleExpression(OPERATORS.AND, "pattern2"),
+        RuleExpr(OPERATORS.AND_INSIDE, "pattern4"),
+        RuleExpr(OPERATORS.AND_NOT, "pattern1"),
+        RuleExpr(OPERATORS.AND, "pattern2"),
     ]
     result = evaluate_expression(expression, results)
     assert result == set([Range(200, 300)]), f"{result}"
@@ -143,9 +148,9 @@ def testD():
         "pattern4": [SRange(0, 1000)],
     }
     expression = [
-        BooleanRuleExpression(OPERATORS.AND_NOT_INSIDE, "pattern4"),
-        BooleanRuleExpression(OPERATORS.AND_NOT, "pattern1"),
-        BooleanRuleExpression(OPERATORS.AND, "pattern2"),
+        RuleExpr(OPERATORS.AND_NOT_INSIDE, "pattern4"),
+        RuleExpr(OPERATORS.AND_NOT, "pattern1"),
+        RuleExpr(OPERATORS.AND, "pattern2"),
     ]
     result = evaluate_expression(expression, results)
     assert result == set([]), f"{result}"
@@ -184,9 +189,9 @@ def testE():
         "pattern3": [SRange(200, 600)],
     }
     expression = [
-        BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern3"),
-        BooleanRuleExpression(OPERATORS.AND_NOT_INSIDE, "pattern2"),
-        BooleanRuleExpression(OPERATORS.AND, "pattern1"),
+        RuleExpr(OPERATORS.AND_INSIDE, "pattern3"),
+        RuleExpr(OPERATORS.AND_NOT_INSIDE, "pattern2"),
+        RuleExpr(OPERATORS.AND, "pattern1"),
     ]
     result = evaluate_expression(expression, results)
     assert result == set([Range(300, 400), Range(350, 400)]), f"{result}"
@@ -198,9 +203,9 @@ def testE():
         OUTPUT: [100-200]
     """
     expression = [
-        BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern2"),
-        BooleanRuleExpression(OPERATORS.AND_NOT_INSIDE, "pattern3"),
-        BooleanRuleExpression(OPERATORS.AND, "pattern1"),
+        RuleExpr(OPERATORS.AND_INSIDE, "pattern2"),
+        RuleExpr(OPERATORS.AND_NOT_INSIDE, "pattern3"),
+        RuleExpr(OPERATORS.AND, "pattern1"),
     ]
     result = evaluate_expression(expression, results)
     assert result == set([Range(100, 200)]), f"{result}"
@@ -209,7 +214,7 @@ def testE():
         and-inside P1
         OUTPUT: [100-200, 300-400, 350-400, 500-600]
     """
-    expression = [BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern1")]
+    expression = [RuleExpr(OPERATORS.AND_INSIDE, "pattern1")]
     result = evaluate_expression(expression, results)
     assert result == set(
         [Range(100, 200), Range(300, 400), Range(350, 400), Range(500, 600)]
@@ -272,15 +277,15 @@ def testF():
     }
 
     subexpression1 = [
-        BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern4"),
-        BooleanRuleExpression(OPERATORS.AND, "pattern2"),
+        RuleExpr(OPERATORS.AND_INSIDE, "pattern4"),
+        RuleExpr(OPERATORS.AND, "pattern2"),
     ]
     subexpression2 = [
-        BooleanRuleExpression(OPERATORS.AND_NOT_INSIDE, "pattern4"),
-        BooleanRuleExpression(OPERATORS.AND, "pattern1"),
+        RuleExpr(OPERATORS.AND_NOT_INSIDE, "pattern4"),
+        RuleExpr(OPERATORS.AND, "pattern1"),
     ]
     expression = [
-        BooleanRuleExpression(OPERATORS.AND_INSIDE, "pattern3"),
+        RuleExpr(OPERATORS.AND_INSIDE, "pattern3"),
         BooleanRuleExpression(
             OPERATORS.AND_EITHER,
             None,
@@ -379,7 +384,7 @@ def testEvaluatePython():
     }
 
     expression = [
-        BooleanRuleExpression(OPERATORS.AND, "all_execs"),
+        BooleanRuleExpression(OPERATORS.AND, "all_execs", None, "all_execs"),
         BooleanRuleExpression(
             OPERATORS.WHERE_PYTHON, "p1", None, "vars['$X'].startswith('cmd')"
         ),


### PR DESCRIPTION
Trying to make the yaml errors less confusing to the end user, closes issue https://github.com/returntocorp/sgrep/issues/210
```
testlint/python/bad.yaml: inside rule 1 (rule id: eqeq-is-bad), pattern fields can't look like this: only ['patterns', 'pattern-either'] operators can have children, but found `and_inside` with children

testlint/python/bad2.yaml has invalid rule key at rule 1 (rule id: eqeq-is-bad), can only have: {'patterns', 'languages', 'id', 'severity', 'pattern', 'message'}

testlint/python/bad3.yaml: inside rule 1 (rule id: test-pattern), pattern fields can't look like this: operand of operator `pattern` ought to have type string, but is <class 'list'>: [{'pattern': '$D = {}'}]
```

