### PR TITLE
improve parsing error for invalid types in valid yaml

### DIFF
--- a/sgrep_lint/evaluation.py
+++ b/sgrep_lint/evaluation.py
@@ -39,7 +39,7 @@ def _parse_boolean_expression(
     for pattern in rule_patterns:
         if not isinstance(pattern, dict):
             raise InvalidRuleSchema(
-                f"invalid type for pattern {pattern}: {type(pattern)} is not a dict"
+                f"invalid type for pattern {pattern}: {type(pattern)} is not a dict; perhaps you are missing a `-` before {pattern}?"
             )
         for boolean_operator, pattern_text in pattern.items():
             operator = operator_for_pattern_name(boolean_operator)

--- a/sgrep_lint/evaluation.py
+++ b/sgrep_lint/evaluation.py
@@ -32,7 +32,15 @@ def _parse_boolean_expression(
     """
     Move through the expression from the YML, yielding tuples of (operator, unique-id-for-pattern, pattern)
     """
+    if not isinstance(rule_patterns, list):
+        raise InvalidRuleSchema(
+            f"invalid type for pattern {rule_patterns}: {type(rule_patterns)} is not a list"
+        )
     for pattern in rule_patterns:
+        if not isinstance(pattern, dict):
+            raise InvalidRuleSchema(
+                f"invalid type for pattern {pattern}: {type(pattern)} is not a dict"
+            )
         for boolean_operator, pattern_text in pattern.items():
             operator = operator_for_pattern_name(boolean_operator)
             if isinstance(pattern_text, list):

--- a/sgrep_lint/evaluation.py
+++ b/sgrep_lint/evaluation.py
@@ -34,12 +34,12 @@ def _parse_boolean_expression(
     """
     if not isinstance(rule_patterns, list):
         raise InvalidRuleSchema(
-            f"invalid type for pattern {rule_patterns}: {type(rule_patterns)} is not a list"
+            f"invalid type for block {rule_patterns}: {type(rule_patterns)} is not a list; perhaps you are missing a `-` inside {rule_patterns}?"
         )
     for pattern in rule_patterns:
         if not isinstance(pattern, dict):
             raise InvalidRuleSchema(
-                f"invalid type for pattern {pattern}: {type(pattern)} is not a dict; perhaps you are missing a `-` before {pattern}?"
+                f"invalid type for pattern {pattern}: {type(pattern)} is not a dict"
             )
         for boolean_operator, pattern_text in pattern.items():
             operator = operator_for_pattern_name(boolean_operator)

--- a/sgrep_lint/tests/python/bad4.yaml
+++ b/sgrep_lint/tests/python/bad4.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: arg-reassign
+    patterns:
+        pattern-inside: |
+            def foo($X):
+                ...
+        pattern: $X = 1
+    message: "$X is being reassigned"
+    languages: [python]
+    severity: WARNING

--- a/sgrep_lint/tests/run-lint-tests.sh
+++ b/sgrep_lint/tests/run-lint-tests.sh
@@ -107,5 +107,8 @@ $SGREP --strict --config tests/python/bad2.yaml tests/lint && echo "bad2.yaml sh
 # parsing bad3.yaml should fail
 $SGREP --strict --config tests/python/bad3.yaml tests/lint && echo "bad3.yaml should have failed" && exit 1
 
+# parsing bad4.yaml should fail
+$SGREP --strict --config tests/python/bad4.yaml tests/lint && echo "bad4.yaml should have failed" && exit 1
+
 echo "-----------------------"
 echo "all lint tests passed"


### PR DESCRIPTION
Fixes issue with https://sgrep.live/6xY having a bad error message