### PR TITLE
Fix mypy not using strict options

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
     rev: "v0.761"
     hooks:
       - id: mypy
+        args: [--config, mypy.ini]
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: "3.7.9"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,45 @@
+[mypy]
+# Globals
+python_version = 3.7
+
+# Strict typing options
+
+mypy_path = ./stubs
+
+# Avoid configuration issues
+warn_unused_configs = True
+
+# Import Discovery
+ignore_missing_imports = False
+follow_imports = True
+
+# Dynamic typing
+disallow_subclassing_any = True
+disallow_any_generics = False
+disallow_any_unimported = True
+disallow_any_expr = False
+disallow_any_decorated = True
+disallow_any_explicit = False
+
+# Untyped definitions and calls
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+
+# Implicit optional
+no_implicit_optional = True
+
+# Other warns
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = True
+
+# Ignore missing imports for third party libraries without type stubs
+# Must have one entry per package
+# Should reduce the size of this section as time goes on
+
+# colorama
+[mypy-colorama]
+ignore_missing_imports = True

--- a/sgrep_lint/config_resolver.py
+++ b/sgrep_lint/config_resolver.py
@@ -3,26 +3,20 @@ import os
 import shutil
 import sys
 import tarfile
-import tempfile
 import time
 from pathlib import Path
 from typing import Any
-from typing import DefaultDict
 from typing import Dict
-from typing import Generator
-from typing import Iterable
-from typing import Iterator
 from typing import List
-from typing import NewType
 from typing import Optional
-from typing import Set
-from typing import Tuple
 
 import requests
 import yaml
 from constants import DEFAULT_CONFIG_FILE
 from constants import DEFAULT_CONFIG_FOLDER
 from constants import DEFAULT_SGREP_CONFIG_NAME
+from constants import ID_KEY
+from constants import RULES_KEY
 from constants import YML_EXTENSIONS
 from util import debug_print
 from util import is_url
@@ -33,9 +27,6 @@ from util import print_msg
 IN_DOCKER = "SGREP_IN_DOCKER" in os.environ
 IN_GH_ACTION = "GITHUB_WORKSPACE" in os.environ
 REPO_HOME_DOCKER = "/home/repo/"
-
-
-from constants import RULES_KEY, ID_KEY
 
 TEMPLATE_YAML_URL = (
     "https://raw.githubusercontent.com/returntocorp/sgrep-rules/develop/template.yaml"
@@ -73,7 +64,7 @@ def resolve_targets(targets: List[str]) -> List[Path]:
     ]
 
 
-def adjust_for_docker(in_precommit: bool = False):
+def adjust_for_docker(in_precommit: bool = False) -> None:
     # change into this folder so that all paths are relative to it
     if IN_DOCKER and not IN_GH_ACTION and not in_precommit:
         if not Path(REPO_HOME_DOCKER).exists():
@@ -124,12 +115,12 @@ def parse_config_folder(
 ) -> Dict[str, Optional[Dict[str, Any]]]:
     configs = {}
     for l in loc.rglob("*"):
-        if not _hidden_config_dir(l) and l.suffix in YML_EXTENSIONS:
+        if not _is_hidden_config_dir(l) and l.suffix in YML_EXTENSIONS:
             configs.update(parse_config_at_path(l, loc if relative else None))
     return configs
 
 
-def _hidden_config_dir(loc: Path):
+def _is_hidden_config_dir(loc: Path) -> bool:
     """
     Want to keep rules/.sgrep.yml but not path/.github/foo.yml
     Also want to keep src/.sgrep/bad_pattern.yml
@@ -204,7 +195,7 @@ def download_config(config_url: str) -> Dict[str, Optional[Dict[str, Any]]]:
             )
             assert False
     except Exception as e:
-        print_error(e)
+        print_error(str(e))
     return {config_url: None}
 
 
@@ -224,7 +215,7 @@ def resolve_config(config_str: Optional[str]) -> Dict[str, Optional[Dict[str, An
     return config
 
 
-def generate_config():
+def generate_config() -> None:
     # defensive coding
     if Path(DEFAULT_CONFIG_FILE).exists():
         print_error_exit(
@@ -251,4 +242,4 @@ def generate_config():
             print_msg(f"Template config successfully written to {DEFAULT_CONFIG_FILE}")
             sys.exit(0)
     except Exception as e:
-        print_error_exit(e)
+        print_error_exit(str(e))

--- a/sgrep_lint/evaluation.py
+++ b/sgrep_lint/evaluation.py
@@ -1,19 +1,14 @@
 from typing import Any
-from typing import DefaultDict
 from typing import Dict
-from typing import Generator
 from typing import Iterable
 from typing import Iterator
 from typing import List
-from typing import NewType
 from typing import Optional
 from typing import Set
-from typing import Tuple
 
 from constants import RCE_RULE_FLAG
 from sgrep_types import BooleanRuleExpression
 from sgrep_types import InvalidRuleSchema
-from sgrep_types import Operator
 from sgrep_types import operator_for_pattern_name
 from sgrep_types import OPERATORS
 from sgrep_types import pattern_name_for_operator
@@ -28,7 +23,7 @@ from util import print_error_exit
 
 
 def _parse_boolean_expression(
-    rule_patterns: List[Dict[str, Any]], pattern_id=0, prefix=""
+    rule_patterns: List[Dict[str, Any]], pattern_id: int = 0, prefix: str = ""
 ) -> Iterator[BooleanRuleExpression]:
     """
     Move through the expression from the YML, yielding tuples of (operator, unique-id-for-pattern, pattern)
@@ -172,9 +167,9 @@ def _where_python_statement_matches(
         )
 
     if type(output) != type(True):  # type: ignore
-        print_error_exit(  # type: ignore
+        print_error_exit(
             f"python where expression needs boolean output but got: {output} for {where_expression}"  # type: ignore
-        )  # type: ignore
+        )
     return output == True  # type: ignore
 
 

--- a/sgrep_lint/sgrep_types.py
+++ b/sgrep_lint/sgrep_types.py
@@ -1,21 +1,9 @@
 from dataclasses import dataclass
-from dataclasses import field
-from typing import Any
-from typing import DefaultDict
 from typing import Dict
-from typing import Generator
-from typing import Iterable
-from typing import Iterator
 from typing import List
 from typing import NewType
 from typing import Optional
-from typing import Set
-from typing import Tuple
 
-import colorama
-import requests
-import yaml
-from util import print_error_exit
 
 PatternId = NewType("PatternId", str)
 Operator = NewType("Operator", str)
@@ -68,10 +56,10 @@ class BooleanRuleExpression:
     children: Optional[List["BooleanRuleExpression"]] = None
     operand: Optional[str] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self._validate()
 
-    def _validate(self):
+    def _validate(self) -> None:
         if self.operator in set(OPERATORS_WITH_CHILDREN):
             if self.operand is not None:
                 raise InvalidRuleSchema(
@@ -111,10 +99,10 @@ class Range:
     start: int
     end: int
 
-    def is_enclosing_or_eq(self, other_range):
+    def is_enclosing_or_eq(self, other_range: "Range") -> bool:
         return self.start <= other_range.start and other_range.end <= self.end
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.start}-{self.end}"
 
 
@@ -125,5 +113,5 @@ class SgrepRange:
     range: Range  # The range of the match
     metavars: Dict[str, str]  # Any matched metavariables, {"$NAME": "<matched text>"}
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.range}-{self.metavars}"

--- a/sgrep_lint/test.py
+++ b/sgrep_lint/test.py
@@ -93,7 +93,7 @@ def line_has_todo_ok(line: str) -> bool:
 
 
 def score_output_json(
-    json_out, test_files: List[Path], ignore_todo: bool
+    json_out: Dict[str, Any], test_files: List[Path], ignore_todo: bool
 ) -> Tuple[Dict[str, List[int]], Dict[str, Dict[str, Any]], int]:
     comment_lines: Dict[str, Dict[str, List[int]]] = collections.defaultdict(
         lambda: collections.defaultdict(list)

--- a/sgrep_lint/util.py
+++ b/sgrep_lint/util.py
@@ -20,9 +20,9 @@ def is_url(url: str) -> bool:
         return False
 
 
-def print_error(e):
+def print_error(e: str) -> None:
     if not QUIET:
-        print(str(e), file=sys.stderr)
+        print(e, file=sys.stderr)
 
 
 def print_error_exit(msg: str, exit_code: int = FATAL_EXIT_CODE) -> None:
@@ -31,12 +31,12 @@ def print_error_exit(msg: str, exit_code: int = FATAL_EXIT_CODE) -> None:
     sys.exit(exit_code)
 
 
-def print_msg(msg: str):
+def print_msg(msg: str) -> None:
     if not QUIET:
         print(msg, file=sys.stderr)
 
 
-def debug_print(msg: str):
+def debug_print(msg: str) -> None:
     if DEBUG:
         print(msg, file=sys.stderr)
 
@@ -53,8 +53,8 @@ def set_flags(debug: bool, quiet: bool) -> None:
     global DEBUG
     global QUIET
     if debug:
-        DEBUG = True  # type: ignore
+        DEBUG = True
         debug_print("DEBUG is on")
     if quiet:
-        QUIET = True  # type: ignore
+        QUIET = True
         debug_print("QUIET is on")

--- a/stubs/astpretty.pyi
+++ b/stubs/astpretty.pyi
@@ -1,0 +1,5 @@
+import ast
+
+
+def pprint(tree: ast.AST) -> None:
+    ...


### PR DESCRIPTION
mypy by default does not run stricter checks. This turns on some
more of the strict mypy options and fixes the codebase to be compliant
with the new stricter settings.