### PR TITLE
Support 'var' matching also 'let' and 'const'

### DIFF
--- a/sgrep/tests/js/equivalence_varlet.js
+++ b/sgrep/tests/js/equivalence_varlet.js
@@ -1,0 +1,9 @@
+//ERROR: match
+var x = "hello";
+
+//ERROR: match
+let x = "hello";
+
+//ERROR: match
+const x = "hello";
+

--- a/sgrep/tests/js/equivalence_varlet.sgrep
+++ b/sgrep/tests/js/equivalence_varlet.sgrep
@@ -1,0 +1,1 @@
+var $X = "hello";


### PR DESCRIPTION
This is especially useful for JS (maybe too JS-specific)

Test plan:
test files included