### PR TITLE
Add --exclude to sgrep

### DIFF
--- a/sgrep_lint/sgrep.py
+++ b/sgrep_lint/sgrep.py
@@ -61,6 +61,12 @@ if __name__ == "__main__":
         help=f"only invoke sgrep if config(s) are valid",
         action="store_true",
     )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        help="Path pattern to exclude. Can be added multiple times to exclude multiple patterns.",
+    )
 
     config.add_argument(
         RCE_RULE_FLAG,

--- a/sgrep_lint/sgrep_main.py
+++ b/sgrep_lint/sgrep_main.py
@@ -8,6 +8,7 @@ import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
+from pathlib import PurePath
 from typing import Any
 from typing import DefaultDict
 from typing import Dict
@@ -643,6 +644,21 @@ def main(args: argparse.Namespace) -> Dict[str, Any]:
         "results": outputs_after_booleans,
         "errors": r2c_error_format(sgrep_errors),
     }
+    if args.exclude:
+        exclude_glob_patterns = args.exclude
+        debug_print(f"patterns to exclude: {', '.join(exclude_glob_patterns)}")
+        filtered_results = [
+            output
+            for output in outputs_after_booleans
+            if not any(
+                PurePath(output.get("path", "")).match(pat)
+                for pat in exclude_glob_patterns
+            )
+        ]
+        debug_print(
+            f"filtered output from {len(outputs_after_booleans)} down to {len(filtered_results)} results"
+        )
+        output_data["results"] = filtered_results
     if not args.quiet:
         if args.json:
             print(build_output_json(output_data))

--- a/sgrep_lint/test.py
+++ b/sgrep_lint/test.py
@@ -185,6 +185,7 @@ def invoke_sgrep_lint(
             validate=False,
             skip_pattern_validation=False,
             exclude_tests=False,
+            exclude=[],
             output=None,
             error=False,
             target=[str(t) for t in test_files],


### PR DESCRIPTION
Note that this just post-processes the output and I would like to pass this down to the sgrep core to save parsing time etc.

Adding this to here instead of bento because most tools, including grep and flake8, have a way for excluding paths and bento can take advantage of that later to avoid parsing time