### PR TITLE
Fix: sgrep-lint printing out number of config files/rules to debug

### DIFF
--- a/sgrep_lint/sgrep_main.py
+++ b/sgrep_lint/sgrep_main.py
@@ -557,7 +557,7 @@ def main(args: argparse.Namespace) -> Dict[str, Any]:
             if len(invalid_configs)
             else ""
         )
-        print_msg(
+        debug_print(
             f"running {len(all_rules)} rules from {len(valid_configs)} config{plural} {config_id_if_single} {invalid_msg}"
         )
     # TODO log valid and invalid configs if verbose


### PR DESCRIPTION
sgrep-lint was printing out information that was not a finding during
the run. Moved to print only when verbose is marked true.