### PR TITLE
Create an initial brew tap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Vim
+.*.sw*

--- a/HomebrewFormula/sgrep-r2c.rb
+++ b/HomebrewFormula/sgrep-r2c.rb
@@ -1,0 +1,18 @@
+class SgrepR2c < Formula
+  version 'v0.4.9b5'
+  #keg_only "maybe?"
+  desc "Like grep but for code"
+  homepage "https://github.com/r2c/sgrep"
+  conflicts_with "sgrep", :because => "we currently include an sgrep binary"
+
+  if OS.mac?
+      url "https://github.com/returntocorp/sgrep/releases/download/v0.4.9b5/sgrep-osx-20b13243a29b4df3176648058df432ef63df7a92.zip"
+      sha256 "49db8437c428ad5bc92828996440609f112447651e19697a90504140e1307101"
+  end
+
+  def install
+    # YOLO. This installs all the libraries into bin/ because libraries
+    # aren't linked properly. /shrug.
+    bin.install Dir["*"]
+  end
+end


### PR DESCRIPTION
This creates a functional (but pretty janky) brew tap based on the
current state of affairs. Lots more downstream work to knock out:
- Automatically build binaries on tags & add to release
- Fixup the tap to use formulae dependencies instead of copying all
these libs
- fix the linker path to actually look for libraries in the right place

WIP for #371 