### PR TITLE
Wrap error entries to be compatible with r2c output

### DIFF
--- a/sgrep_lint/sgrep_main.py
+++ b/sgrep_lint/sgrep_main.py
@@ -350,9 +350,12 @@ def post_output(output_url: str, output_data: Dict[str, Any]) -> None:
 
 
 def build_output_json(output_json: Dict[str, Any]) -> str:
-    # wrap errors under "data" entry to be compatible with 
+    # wrap errors under "data" entry to be compatible with
     # https://docs.r2c.dev/en/latest/api/output.html#errors
-    output_json["errors"] = {"data": output_json["errors"], "message": "SgrepRuntimeErrors"}
+    output_json["errors"] = {
+        "data": output_json["errors"],
+        "message": "SgrepRuntimeErrors",
+    }
     return json.dumps(output_json)
 
 

--- a/sgrep_lint/sgrep_main.py
+++ b/sgrep_lint/sgrep_main.py
@@ -352,10 +352,12 @@ def post_output(output_url: str, output_data: Dict[str, Any]) -> None:
 def build_output_json(output_json: Dict[str, Any]) -> str:
     # wrap errors under "data" entry to be compatible with
     # https://docs.r2c.dev/en/latest/api/output.html#errors
-    output_json["errors"] = {
-        "data": output_json["errors"],
-        "message": "SgrepRuntimeErrors",
-    }
+    errors = output_json["errors"]
+    if errors:
+        output_json["errors"] = {
+            "data": output_json["errors"],
+            "message": "SgrepRuntimeErrors",
+        }
     return json.dumps(output_json)
 
 

--- a/sgrep_lint/sgrep_main.py
+++ b/sgrep_lint/sgrep_main.py
@@ -118,7 +118,6 @@ def invoke_sgrep(
                 )
                 print_error_exit(f"\n\n{PLEASE_FILE_ISSUE_TEXT}")
             output_json = json.loads((output.decode("utf-8", "replace")))
-            # print(f"output json {output_json}")
             errors.extend(output_json["errors"])
             outputs.extend(output_json["matches"])
     return {"matches": outputs, "errors": errors}
@@ -351,6 +350,9 @@ def post_output(output_url: str, output_data: Dict[str, Any]) -> None:
 
 
 def build_output_json(output_json: Dict[str, Any]) -> str:
+    # wrap errors under "data" entry to be compatible with 
+    # https://docs.r2c.dev/en/latest/api/output.html#errors
+    output_json["errors"] = {"data": output_json["errors"], "message": "SgrepRuntimeErrors"}
     return json.dumps(output_json)
 
 


### PR DESCRIPTION
Addresses: https://github.com/returntocorp/enterprise/issues/43. This changes the "errors" in json output to be compatible with https://docs.r2c.dev/en/latest/api/output.html#errors. 
## Testing:

1. make
2. ./build/sgrep.dist/sgrep-lint --json -f ~/Workspace/sgrep-rules/python/django/security/xss-html-email-body.yaml ~/Workspace/rest_xops
3. see the following:

```json
{"results": [], "errors": {"data": [{"check_id": "LexicalError", "path": "/Users/ulziibayarotgonbaatar/Workspace/rest_xops/rest_xops/celery.py", "start": {"line": 32, "col": 35}, "end": {"line": 32, "col": 36}, "extra": {"message": "Lexical error: unrecognized symbol: #", "line": "CELERYD_TASK_TIME_LIMIT = 15 * 60 # \u4efb\u52a1\u8d85\u65f6\u65f6\u95f4"}}, {"check_id": "LexicalError", "path": "/Users/ulziibayarotgonbaatar/Workspace/rest_xops/apps/websocket/consumers/__init__.py", "start": {"line": 2, "col": 1}, "end": {"line": 2, "col": 2}, "extra": {"message": "Lexical error: unrecognized symbol: #", "line": "# @Author  : xufqing"}}, {"check_id": "LexicalError", "path": "/Users/ulziibayarotgonbaatar/Workspace/rest_xops/apps/websocket/__init__.py", "start": {"line": 2, "col": 1}, "end": {"line": 2, "col": 2}, "extra": {"message": "Lexical error: unrecognized symbol: #", "line": "# @Author  : xufqing"}}, {"check_id": "LexicalError", "path": "/Users/ulziibayarotgonbaatar/Workspace/rest_xops/apps/utils/__init__.py", "start": {"line": 2, "col": 1}, "end": {"line": 2, "col": 2}, "extra": {"message": "Lexical error: unrecognized symbol: #", "line": "# @Author  : xufqing"}}, {"check_id": "LexicalError", "path": "/Users/ulziibayarotgonbaatar/Workspace/rest_xops/apps/rbac/views/__init__.py", "start": {"line": 2, "col": 1}, "end": {"line": 2, "col": 2}, "extra": {"message": "Lexical error: unrecognized symbol: #", "line": "# @Author  : xufqing"}}, {"check_id": "LexicalError", "path": "/Users/ulziibayarotgonbaatar/Workspace/rest_xops/apps/rbac/serializers/role_serializer.py", "start": {"line": 25, "col": 5}, "end": {"line": 25, "col": 6}, "extra": {"message": "Lexical error: unrecognized symbol: #", "line": "    #     return menus"}}, {"check_id": "LexicalError", "path": "/Users/ulziibayarotgonbaatar/Workspace/rest_xops/apps/rbac/serializers/__init__.py", "start": {"line": 2, "col": 1}, "end": {"line": 2, "col": 2}, "extra": {"message": "Lexical error: unrecognized symbol: #", "line": "# @Author  : xufqing"}}, {"check_id": "LexicalError", "path": "/Users/ulziibayarotgonbaatar/Workspace/rest_xops/apps/deployment/views/__init__.py", "start": {"line": 2, "col": 1}, "end": {"line": 2, "col": 2}, "extra": {"message": "Lexical error: unrecognized symbol: #", "line": "# @Author  : xufqing"}}, {"check_id": "LexicalError", "path": "/Users/ulziibayarotgonbaatar/Workspace/rest_xops/apps/deployment/serializers/__init__.py", "start": {"line": 2, "col": 1}, "end": {"line": 2, "col": 2}, "extra": {"message": "Lexical error: unrecognized symbol: #", "line": "# @Author  : xufqing"}}, {"check_id": "LexicalError", "path": "/Users/ulziibayarotgonbaatar/Workspace/rest_xops/apps/common/__init__.py", "start": {"line": 2, "col": 1}, "end": {"line": 2, "col": 2}, "extra": {"message": "Lexical error: unrecognized symbol: #", "line": "# @Author  : xufqing"}}, {"check_id": "LexicalError", "path": "/Users/ulziibayarotgonbaatar/Workspace/rest_xops/apps/cmdb/views/__init__.py", "start": {"line": 2, "col": 1}, "end": {"line": 2, "col": 2}, "extra": {"message": "Lexical error: unrecognized symbol: #", "line": "# @Author  : xufqing"}}, {"check_id": "LexicalError", "path": "/Users/ulziibayarotgonbaatar/Workspace/rest_xops/apps/cmdb/serializers/__init__.py", "start": {"line": 2, "col": 1}, "end": {"line": 2, "col": 2}, "extra": {"message": "Lexical error: unrecognized symbol: #", "line": "# @Author  : xufqing"}}, {"check_id": "LexicalError", "path": "/Users/ulziibayarotgonbaatar/Workspace/rest_xops/apps/__init__.py", "start": {"line": 2, "col": 1}, "end": {"line": 2, "col": 2}, "extra": {"message": "Lexical error: unrecognized symbol: #", "line": "# @Author  : xufqing"}}], "message": "SgrepRuntimeErrors"}}
```